### PR TITLE
Et 28 add status to exercise set

### DIFF
--- a/app/controllers/exercise_sets_controller.rb
+++ b/app/controllers/exercise_sets_controller.rb
@@ -4,13 +4,14 @@ class ExerciseSetsController < ApplicationController
   def update
     exercise_set = ExerciseSet.find(params[:id])
     exercise_set.update!(exercise_set_params)
+    exercise_set.update_status
     render json: exercise_set, status: :created
   end
 
   private
 
   def exercise_set_params
-    params.permit(:reps, :weight, :completed_at)
+    params.permit(:reps, :weight, :completed_at, :status)
   end
 
   def render_invalid(invalid)

--- a/app/controllers/exercise_sets_controller.rb
+++ b/app/controllers/exercise_sets_controller.rb
@@ -11,7 +11,7 @@ class ExerciseSetsController < ApplicationController
   private
 
   def exercise_set_params
-    params.permit(:reps, :weight, :completed_at, :status)
+    params.permit(:reps, :weight, :completed_at)
   end
 
   def render_invalid(invalid)

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,6 +1,6 @@
 class Exercise < ApplicationRecord
   belongs_to :blueprint
-  has_many :exercise_sets, dependent: :destroy
+  has_many :exercise_sets, -> { order(:id) }, dependent: :destroy
 
   def self.create_exercise(blueprint_id, workout_id, sets, user_id)
     blueprint = Blueprint.find(blueprint_id)

--- a/app/models/exercise_set.rb
+++ b/app/models/exercise_set.rb
@@ -1,5 +1,10 @@
 class ExerciseSet < ApplicationRecord
   belongs_to :exercise
+  validates :status,
+            inclusion: {
+              in: %w[successful unsuccessful incomplete],
+              message: "%{value} is not a valid status"
+            }
 
   def self.create_exercise_sets(exercise_id, user_id, weight, reps)
     ExerciseSet.create!(
@@ -9,6 +14,20 @@ class ExerciseSet < ApplicationRecord
       completed_at: nil,
       user_id: user_id
     )
+  end
+
+  def update_status
+    if completed_at.present?
+      exercise = Exercise.find_by(id: exercise_id)
+
+      if weight >= exercise.weight && reps >= exercise.reps
+        update!(status: "successful")
+      elsif weight <= exercise.weight || reps <= exercise.reps
+        update!(status: "unsuccessful")
+      end
+    else
+      update!(status: "incomplete")
+    end
   end
 
   #Rails automatically has typcasting when assigning values based off of the

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,5 +1,5 @@
 class Workout < ApplicationRecord
   belongs_to :user
-  has_many :exercises, dependent: :destroy
+  has_many :exercises, -> { order(:id) }, dependent: :destroy
   has_many :exercise_sets, through: :exercises
 end

--- a/app/serializers/exercise_serializer.rb
+++ b/app/serializers/exercise_serializer.rb
@@ -1,4 +1,11 @@
 class ExerciseSerializer < ActiveModel::Serializer
-  attributes :id, :blueprint_id, :name, :pic_url, :workout_id, :instructions
+  attributes :id,
+             :blueprint_id,
+             :name,
+             :pic_url,
+             :workout_id,
+             :instructions,
+             :weight,
+             :reps
   has_many :exercise_sets
 end

--- a/app/serializers/exercise_set_serializer.rb
+++ b/app/serializers/exercise_set_serializer.rb
@@ -1,3 +1,3 @@
 class ExerciseSetSerializer < ActiveModel::Serializer
-  attributes :id, :reps, :weight, :completed_at
+  attributes :id, :reps, :weight, :completed_at, :status
 end

--- a/db/migrate/20230729221447_add_status_to_exercise_sets.rb
+++ b/db/migrate/20230729221447_add_status_to_exercise_sets.rb
@@ -1,0 +1,25 @@
+class AddStatusToExerciseSets < ActiveRecord::Migration[7.0]
+  def up
+    add_column :exercise_sets, :status, :string, default: "incomplete"
+
+    ExerciseSet.reset_column_information
+
+    ExerciseSet.find_each do |exercise_set|
+      if exercise_set.completed_at.present?
+        exercise = Exercise.find_by(id: exercise_set.exercise_id)
+
+        if exercise_set.weight >= exercise.weight &&
+             exercise_set.reps >= exercise.reps
+          exercise_set.update!(status: "successful")
+        elsif exercise_set.weight <= exercise.weight ||
+              exercise_set.reps <= exercise.reps
+          exercise_set.update!(status: "unsuccessful")
+        end
+      end
+    end
+  end
+
+  def down
+    remove_column :exercise_sets, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_06_194017) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_29_221447) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_06_194017) do
     t.datetime "updated_at", null: false
     t.datetime "completed_at"
     t.bigint "user_id", null: false
+    t.string "status", default: "incomplete"
     t.index ["exercise_id"], name: "index_exercise_sets_on_exercise_id"
     t.index ["user_id"], name: "index_exercise_sets_on_user_id"
   end

--- a/spec/exercise_success_spec.rb
+++ b/spec/exercise_success_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Exercise, type: :model do
           user_id: user[:id]
         )
       end
+      debugger
 
       Exercise.create_exercise(blueprint[:id], workout_id, sets, user[:id])
     end

--- a/spec/exercise_success_spec.rb
+++ b/spec/exercise_success_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe Exercise, type: :model do
           user_id: user[:id]
         )
       end
-      debugger
 
       Exercise.create_exercise(blueprint[:id], workout_id, sets, user[:id])
     end


### PR DESCRIPTION
Added Status column to ExerciseSets
new column will only accept 3 strings "successful", "unsuccessful", and "incomplete"
This column cannot be updated directly via params
updates for this column will automatically occur via the update_status method when the ExerciseSet controller receives an update request for weight, reps, and completed_at.