### PR TITLE
Et 37 edit status

### DIFF
--- a/client/src/components/CurrentExerciseCard.tsx
+++ b/client/src/components/CurrentExerciseCard.tsx
@@ -5,6 +5,7 @@ import CurrentExerciseStateIcons, {
   CurrentExerciseStateIconsProps,
   ExerciseSetState,
 } from "./CurrentExerciseStateIcons.tsx";
+import { ExerciseSetStatus } from "./types.ts";
 import CompleteSetButton from "./CompleteSetButton.tsx";
 import EditSetModal from "./EditSetModal.tsx";
 import CurrentExerciseInstructions from "./CurrentExerciseInstructions.tsx";
@@ -13,6 +14,7 @@ type ExerciseSetProps = {
   id: number;
   weight: number;
   reps: number;
+  status: ExerciseSetStatus;
   completedAt?: Date;
 };
 
@@ -48,13 +50,28 @@ export default function CurrentWorkoutCard({
   }
 
   function getIconStates(): CurrentExerciseStateIconsProps[] {
+    const iconStatusToIconStateMap = new Map<
+      ExerciseSetStatus,
+      ExerciseSetState
+    >([
+      [ExerciseSetStatus.SUCCESSFUL, ExerciseSetState.COMPLETE],
+      [ExerciseSetStatus.INCOMPLETE, ExerciseSetState.INCOMPLETE],
+      [ExerciseSetStatus.UNSUCCESSFUL, ExerciseSetState.FAILED],
+    ]);
+
     const iconStates: CurrentExerciseStateIconsProps[] = [];
 
     for (let i = 0; i < exerciseSets.length; i++) {
       const exerciseSet = exerciseSets[i];
-      const state = exerciseSet.completedAt
-        ? ExerciseSetState.COMPLETE
-        : ExerciseSetState.INCOMPLETE;
+
+      const state = iconStatusToIconStateMap.get(exerciseSet.status);
+
+      if (!state) {
+        throw new Error(
+          `Could not find icon state for exercise set status ${exerciseSet.status}`
+        );
+      }
+
       iconStates.push({
         exerciseSetId: exerciseSet.id,
         state,

--- a/client/src/components/CurrentWorkoutPage.tsx
+++ b/client/src/components/CurrentWorkoutPage.tsx
@@ -114,7 +114,11 @@ export default function CurrentWorkoutPage() {
     const response = await fetch(`/exercise_sets/${setId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ weight, reps }),
+      body: JSON.stringify({
+        weight,
+        reps,
+        completed_at: new Date().toISOString(),
+      }),
     });
 
     if (response.ok) {
@@ -176,6 +180,7 @@ export default function CurrentWorkoutPage() {
         <SwipeableViews index={currentExerciseIndex}>
           {currentWorkout.exercises.map((exercise) => (
             <CurrentExerciseCard
+              key={exercise.id}
               id={exercise.id}
               name={exercise.name}
               instructions={exercise.instructions}

--- a/client/src/components/EditSetModal.tsx
+++ b/client/src/components/EditSetModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Modal from "@mui/material/Modal";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -41,6 +41,14 @@ export default function EditSetModal({
   const [reps, setReps] = useState(currentRepAmount);
   const [weight, setWeight] = useState(currentWeightAmount);
 
+  // Reset reps and weight states when the open prop changes
+  useEffect(() => {
+    if (open) {
+      setReps(currentRepAmount);
+      setWeight(currentWeightAmount);
+    }
+  }, [open, currentRepAmount, currentWeightAmount]);
+
   const changeReps = (action: Action) => {
     if (action === Action.INCREMENT) {
       setReps((prevReps) => prevReps + 1);
@@ -53,10 +61,10 @@ export default function EditSetModal({
 
   const changeWeight = (action: Action) => {
     if (action === Action.INCREMENT) {
-      setWeight((prevWeight) => prevWeight + 1);
+      setWeight((prevWeight) => prevWeight + 0.5);
     } else {
       if (weight > 0) {
-        setWeight((prevWeight) => prevWeight - 1);
+        setWeight((prevWeight) => prevWeight - 0.5);
       }
     }
   };

--- a/client/src/components/translator.ts
+++ b/client/src/components/translator.ts
@@ -1,4 +1,20 @@
-import { RawCurrentWorkout, CurrentWorkout } from "./types";
+import { RawCurrentWorkout, CurrentWorkout, ExerciseSetStatus } from "./types.ts";
+
+function getExerciseSetStatus(rawExcerciseSetStatus: string): ExerciseSetStatus {
+  const exerciseSetStatusMap = new Map<string, ExerciseSetStatus>([
+    ["successful", ExerciseSetStatus.SUCCESSFUL],
+    ["unsuccessful", ExerciseSetStatus.UNSUCCESSFUL],
+    ["incomplete", ExerciseSetStatus.INCOMPLETE],
+  ]);
+
+  const status = exerciseSetStatusMap.get(rawExcerciseSetStatus);
+
+  if (!status) {
+    throw new Error(`Unknown exercise set status: ${rawExcerciseSetStatus}`);
+  }
+
+  return status;
+}
 
 export function translateRawCurrentWorkout(
   rawCurrentWorkout: RawCurrentWorkout
@@ -21,6 +37,7 @@ export function translateRawCurrentWorkout(
               reps: rawExerciseSet.reps,
               weight: rawExerciseSet.weight,
               completedAt: rawExerciseSet.completed_at,
+              status: getExerciseSetStatus(rawExerciseSet.status),
             };
           })
           .sort((a, b) => a.id - b.id),

--- a/client/src/components/translator.ts
+++ b/client/src/components/translator.ts
@@ -1,6 +1,12 @@
-import { RawCurrentWorkout, CurrentWorkout, ExerciseSetStatus } from "./types.ts";
+import {
+  RawCurrentWorkout,
+  CurrentWorkout,
+  ExerciseSetStatus,
+} from "./types.ts";
 
-function getExerciseSetStatus(rawExcerciseSetStatus: string): ExerciseSetStatus {
+function getExerciseSetStatus(
+  rawExcerciseSetStatus: string
+): ExerciseSetStatus {
   const exerciseSetStatusMap = new Map<string, ExerciseSetStatus>([
     ["successful", ExerciseSetStatus.SUCCESSFUL],
     ["unsuccessful", ExerciseSetStatus.UNSUCCESSFUL],

--- a/client/src/components/types.ts
+++ b/client/src/components/types.ts
@@ -3,6 +3,7 @@ export type RawExerciseSet = {
   reps: number;
   weight: number;
   completed_at?: Date;
+  status: string;
 };
 
 export type RawCurrentExercise = {
@@ -22,11 +23,18 @@ export type RawCurrentWorkout = {
   completed_at?: Date;
 };
 
+export enum ExerciseSetStatus {
+  SUCCESSFUL = "SUCCESSFUL",
+  UNSUCCESSFUL = "UNSUCCESSFUL",
+  INCOMPLETE = "INCOMPLETE",
+}
+
 export type ExerciseSet = {
   id: number;
   reps: number;
   weight: number;
   completedAt?: Date;
+  status: ExerciseSetStatus;
 };
 
 export type CurrentExercise = {


### PR DESCRIPTION
- Uses status coming from the API
- Sets `completed_at` when you close the edit modal

![Screen Recording 2023-08-05 at 6 44 55 AM](https://github.com/Toxicity1314/Exercise-tracker/assets/9446332/613c0935-0c95-4c74-abb1-e99b4ddf4535)
